### PR TITLE
chore: update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - iojs
+  - "5"
+  - "4"
   - "0.12"
   - "0.10"


### PR DESCRIPTION
Remove iojs in favor of Node 4 and Node 5