### PR TITLE
Wrapped file paths in path.normalize in test/main.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.node
 components
 coverage
+*.swp

--- a/test/main.js
+++ b/test/main.js
@@ -168,9 +168,9 @@ describe('gulp-concat', function() {
 
       it('should calculate relative path from cwd and path in arguments', function (done) {
         test('wadap')
-          .pipe(concat({cwd: '/home/contra', path: '/home/contra/test/new.txt'}))
+          .pipe(concat({cwd: path.normalize('/home/contra'), path: path.normalize('/home/contra/test/new.txt')}))
           .pipe(assert.length(1))
-          .pipe(assert.first(function (d) { d.relative.should.eql('test/new.txt'); }))
+          .pipe(assert.first(function (d) { d.relative.should.eql(path.normalize('test/new.txt')); }))
           .pipe(assert.end(done));
       });
     });


### PR DESCRIPTION
I've wrapped the file paths that contain delimiters in path.normalize to address the failing tests on windows I mentioned in #117

Can somebody with access to a unix machine confirm this works for me?